### PR TITLE
Action and filter hook

### DIFF
--- a/attachments.php
+++ b/attachments.php
@@ -527,7 +527,7 @@ function attachments_save($post_id)
                     'order'             => intval( $_POST['attachment_order_' . $i] )
                     );
                     
-                $attachment_details = apply_filters('attachments_save_attachment_details', $attachment_details', $attachment_id, $post_id);
+                $attachment_details = apply_filters('attachments_save_attachment_details', $attachment_details, $attachment_id, $post_id);
 
                 // serialize data and encode
                 $attachment_serialized = base64_encode( serialize( $attachment_details ) );


### PR DESCRIPTION
As suggested in [this thread](http://wordpress.org/support/topic/plugin-attachments-filters-and-actions), I've added a number of action and filter hooks throughout the Attachments code that should make it easier to customise and integrate it with other aspects of a site.

I note with approval that most of the visible strings are already internationalised, meaning they can be changed for a specific site (if for example a client wanted to call them "Documents" rather than "Attachments".

I've been quite generous with the actions, since people might want to put their modifications in different places depending on their unique needs.
### Actions
- `attachments_init` - after initialising the plugin
- `attachments_edit_post_types_before` - at the start of the settings page (but after the heading)
- `attachments_edit_post_types_after` - at the end of the settings page (but before the Save button)
- `attachments_meta_before` - at the start of the meta box
- `attachments_list_before` - at the start of the list in the meta box (but after the _Attach_ button, and only if there are attachments to display)
- `attachments_list_item_before` - at the start of a single attachment's entry in the meta box (but after the title)
- `attachments_list_item_after` - at the end of a single attachment's entry in the meta box
- `attachments_list_after` - at the end of the list in the meta box (but only if there are attachments to display)
- `attachments_meta_after` - at the end of the meta box
- `attachments_save` - after saving attachments
### Filters
- `attachments_post_types` - the post type options to display on the settings page
  
  `[ id => { labels: { name }, name } ]`
- `attachments_save_attachment_ids` - the ids of attachments to save for a given post (also passes `$post_id`)
  
  `[ id ]`
- `attachments_save_attachment_details` - the attachment data to be serialised (also passes `$attachment_id` and `$post_id`)
  
  `[ id, title, caption, order ]`
- `attachments_get_filesize_formatted` - the formatted file size for a given attachment (also passes `$path`)
  
  `string`
- `attachments_get_attachments` - the list of attachments for the given post
  
  `[ [ id, name, mime, title, caption, filesize, location, order ] ]`
