### PR TITLE
Fixed items not appearing in thickbox media library

### DIFF
--- a/attachments.php
+++ b/attachments.php
@@ -335,7 +335,7 @@ function attachments_add()
 
                 <ul id="attachments-actions">
                     <li>
-                        <a id="attachments-thickbox" href="media-upload.php?type=image&amp;TB_iframe=1&amp;width=640&amp;height=1500&amp;attachments_thickbox=1" title="Attachments" class="button button-highlighted">
+                        <a id="attachments-thickbox" href="media-upload.php?TB_iframe=1&amp;width=640&amp;height=1500&amp;attachments_thickbox=1" title="Attachments" class="button button-highlighted">
                             <?php _e( 'Attach', 'attachments' ) ?>
                         </a>
                     </li>


### PR DESCRIPTION
When trying to attach a previously uploaded item from the media library, no items would be listed despite them being recognised i.e. shown in the type counter  "Images (10)".

Removing the type=image argument in the media-upload.php request solves this.

This wasn't an issue before, just experienced it with a new Wordpress 3.4.2 site.
