### PR TITLE
Attachments stuck in legacy mode

### DIFF
--- a/index.php
+++ b/index.php
@@ -32,7 +32,7 @@ if( !version_compare( PHP_VERSION, '5.2', '>=' ) && IS_ADMIN && ( !defined( 'DOI
 else
 {
 
-    if( ( defined( 'ATTACHMENTS_LEGACY' ) && ATTACHMENTS_LEGACY === true ) || version_compare( $wp_version, '3.5', '<=' ) )
+    if( ( defined( 'ATTACHMENTS_LEGACY' ) && ATTACHMENTS_LEGACY === true ) || version_compare( $wp_version, '3.5', '<' ) )
     {
         // load deprecated version of Attachments
         require_once 'deprecated/attachments.php';


### PR DESCRIPTION
version_compare's conditional checks if  is <= 3.5 when it should just be < 3.5
