### PR TITLE
Add title() to Attachments class

### DIFF
--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -189,8 +189,21 @@ if ( !class_exists( 'Attachments' ) ) :
             $asset = wp_get_attachment_image_src( $this->attachments[$this->attachments_ref]->id, null, true );
             return $asset;
         }
+        
+        
 
-
+        /**
+         * Returns the original title
+         *
+         * @since 3.0.8.2
+         */
+        function title()
+        {
+            $asset = get_the_title( $this->attachments[$this->attachments_ref]->id );
+            return $asset;
+        }
+        
+        
 
         /**
          * Returns an appropriate <img /> for the current Attachment if it's an image


### PR DESCRIPTION
`title()` returns original attachment title.

Unfortunately, I cannot update PHP version to 5.4+ but do need support for UTF-8. Original attachment titles are saved correctly, so I decided to use `$attachments->title();` instead of `$attachments->field( 'title' );`

Related to https://github.com/jchristopher/attachments/issues/11
