### PR TITLE
Implemented <select> field type

### DIFF
--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -599,6 +599,7 @@ if ( !class_exists( 'Attachments' ) ) :
             $field_types = array(
                 'text'      => ATTACHMENTS_DIR . 'classes/fields/class.field.text.php',
                 'textarea'  => ATTACHMENTS_DIR . 'classes/fields/class.field.textarea.php',
+                'select' 	=> ATTACHMENTS_DIR . 'classes/fields/class.field.select.php',
                 'wysiwyg'   => ATTACHMENTS_DIR . 'classes/fields/class.field.wysiwyg.php',
             );
 
@@ -651,7 +652,8 @@ if ( !class_exists( 'Attachments' ) ) :
             $defaults = array(
                     'name'      => 'title',
                     'type'      => 'text',
-                    'label'     => __( 'Title', 'attachments' ),
+                    'label'     => __( 'Title', 'attachments' ), 
+                    'meta'		=> array()
                 );
 
             $params = array_merge( $defaults, $params );
@@ -660,15 +662,18 @@ if ( !class_exists( 'Attachments' ) ) :
             if( !isset( $this->fields[$params['type']] ) )
                return false;
 
-           // sanitize
-           if( isset( $params['name'] ) )
+            // sanitize
+            if( isset( $params['name'] ) )
                $params['name'] = str_replace( '-', '_', sanitize_title( $params['name'] ) );
 
             if( isset( $params['label'] ) )
                 $params['label'] = __( esc_html( $params['label'] ) );
-
+			
+            if( ( !isset( $params['meta'] ) ) || ( ( isset( $params['meta'] ) ) && ( !is_array( $params['meta'] ) ) ) )
+                $params['meta'] = array();
+			
             // instantiate the class for this field and send it back
-            return new $this->fields[ $params['type'] ]( $params['name'], $params['label'] );
+            return new $this->fields[ $params['type'] ]( $params['name'], $params['label'], null, $params['meta'] );
         }
 
 
@@ -863,10 +868,11 @@ if ( !class_exists( 'Attachments' ) ) :
             {
                 $name   = sanitize_title( $field['name'] );
                 $label  = esc_html( $field['label'] );
-
+                $meta	= ( ( isset( $field['meta'] ) ) ? $field['meta'] : array() );
+				
                 $value  = ( isset( $attachment->fields->$name ) ) ? $attachment->fields->$name : null;
 
-                $field  = new $this->fields[$type]( $name, $label, $value );
+                $field  = new $this->fields[$type]( $name, $label, $value, $meta );
                 $field->value = $field->format_value_for_input( $field->value );
 
                 // does this field already have a unique ID?

--- a/classes/class.field.php
+++ b/classes/class.field.php
@@ -28,12 +28,14 @@ if ( !class_exists( 'Attachments_Field' ) ) :
         public $type;           // field type as it was registered
         public $uid;            // unique id for field
         public $value;          // the value for the field
+        public $meta;			// associated metadata for the field (i.e., an array containing the values for a select box)
 
-        function __construct( $name = 'name', $label = 'Name', $value = null )
+        function __construct( $name = 'name', $label = 'Name', $value = null, $meta = array() )
         {
             $this->name     = sanitize_title( $name );
             $this->label    = __( esc_attr( $label) );
             $this->value    = $value;
+            $this->meta		= $meta;
         }
 
         function set_field_instance( $instance, $field )

--- a/classes/fields/class.field.select.php
+++ b/classes/fields/class.field.select.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Attachments text field
+ *
+ * @package Attachments
+ * @subpackage Main
+ */
+
+class Attachments_Field_Select extends Attachments_Field implements Attachments_Field_Template
+{
+	private $options;
+	
+    function __construct( $name = 'name', $label = 'Name', $value = null, $meta = array() )
+    {
+		
+		$this->options		= $meta;
+		
+        parent::__construct( $name, $label, $value, $meta );
+    }
+
+    function html( $field )
+    {
+    ?>
+    	<select name="<?php esc_attr_e( $field->field_name ); ?>" id="<?php esc_attr_e( $field->field_id ); ?>" class="attachments attachments-field attachments-field-<?php esc_attr_e( $field->field_name ); ?> attachments-field-<?php esc_attr_e( $field->field_id ); ?>">
+        	<option value="">&mdash;</option>
+            <?php
+			foreach ( $this->options as $opt_value => $opt_label )
+			{
+			?>
+            <option value="<?php esc_attr_e( $opt_value ); ?>"<?php if( esc_attr( $opt_value ) == esc_attr( $field->value ) ) echo " selected"; ?>><?php esc_attr_e( $opt_label ); ?> (<?php esc_attr_e( $opt_value ); ?>)</option>
+            <?php
+			}
+			?>
+        </select>
+    <?php
+    }
+
+    function format_value_for_input( $value, $field = null  )
+    {
+        return htmlspecialchars( $value, ENT_QUOTES );
+    }
+
+    public function assets()
+    {
+        return;
+    }
+
+    function init()
+    {
+        return;
+    }
+
+}


### PR DESCRIPTION
Fields can now take a fourth (optional) parameter during register()
calls.

This parameter, indexed as 'meta', is an array.  For selectboxes, it's
implemented to use key/value pairs. (For example: `$my_options['USA'] =
'United States'`)

---

Sample usage inside a register() call:

``` php
$fields = array( array( 'name' => 'lang',
'type' => 'select',
'label' => 'Language',
'meta' => array( 'en' => 'English',
'es' => 'Spanish',
'fr' => 'French')
));

$args = array( 'label' => 'Files',
'post_type' => array( 'page' ),
'filetype' => null,
'note' => '',
'button_text' => __( 'Attach Files', 'attachments' ),
'modal_text' => __( 'Attach', 'attachments' ),
'fields' => $fields);

$attachments->register( 'my_custom_instance_name', $args );
```
