### PR TITLE
Custom meta key

### DIFF
--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -90,8 +90,8 @@ if ( !class_exists( 'Attachments' ) ) :
             add_action( 'admin_footer',                 array( $this, 'admin_footer' ) );
             add_action( 'save_post',                    array( $this, 'save' ) );
 
-			// check if a different meta key has been specified
-			add_action( 'after_setup_theme',            array( $this, 'meta_key_override' ), 999 );
+            // check if a different meta key has been specified
+            add_action( 'after_setup_theme',            array( $this, 'meta_key_override' ), 999 );
 
             // only show the Settings screen if it hasn't been explicitly disabled
             if( !( defined( 'ATTACHMENTS_SETTINGS_SCREEN' ) && ATTACHMENTS_SETTINGS_SCREEN === false ) )
@@ -113,10 +113,10 @@ if ( !class_exists( 'Attachments' ) ) :
         /**
          * Allows a different meta key to be used
          */
-		function meta_key_override() {
-			if ( defined('ATTACHMENTS_META_KEY') )
-				$this->meta_key = ATTACHMENTS_META_KEY;
-		}
+        function meta_key_override() {
+            if ( defined('ATTACHMENTS_META_KEY') )
+                $this->meta_key = ATTACHMENTS_META_KEY;
+        }
 
 
 


### PR DESCRIPTION
I ran into trouble trying to integrate with two existing WP projects already using the 'attachments' post meta key and urgently needed a way to filter the key.

I thought an implementation of `apply_filters` would be nice, but since there's already the approach of using constants for general options (vs per instance), I went with constants instead.

So, for example:

`define('ATTACHMENTS_META_KEY', '_custom_meta_key');`

The added benefit is being able to use an underscore-prefixed meta key, so it doesn't show up in the built-in custom fields meta box. I figured version 3 and above moved away from `_attachments` for legacy reasons.
