### PR TITLE
Missing $index in src() & image() functions

### DIFF
--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -412,7 +412,7 @@ if ( !class_exists( 'Attachments' ) ) :
          */
         function image( $size = 'thumbnail', $index = null )
         {
-            $asset = $this->asset( $size );
+            $asset = $this->asset( $size , $index);
 
             $image_src      = $asset[0];
             $image_width    = $asset[1];
@@ -434,7 +434,7 @@ if ( !class_exists( 'Attachments' ) ) :
          */
         function src( $size = 'thumbnail', $index = null )
         {
-            $asset = $this->asset( $size );
+            $asset = $this->asset( $size , $index);
             return $asset[0];
         }
 


### PR DESCRIPTION
Hi Jonathan,

great plugin, thanks a lot. 

I think i found an issue after calling the `get_single()` function, then using `src()` or `image()` function and passing an index. 
Inside these funtions (line 402 & 424) there is a call to `$this->asset($size)` without passing the index. This results in a default picture from wp-includes. 
