### PR TITLE
Fix bug: passing non variable to end function

### DIFF
--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -1349,7 +1349,7 @@ if( !class_exists( 'Attachments' ) ) :
 
                             $attachment->width      = isset( $attachment_meta['width'] ) ? $attachment_meta['width'] : null;
                             $attachment->height     = isset( $attachment_meta['height'] ) ? $attachment_meta['height'] : null;
-                            $attachment->filename   = end( explode( "/", $attachment_meta['file'] ) );
+                            $attachment->filename   = basename( $attachment_meta['file'] );
 
                             $attachment_mime        = explode( '/', get_post_mime_type( $attachment->id ) );
                             $attachment->type       = isset( $attachment_mime[0] ) ? $attachment_mime[0] : null;


### PR DESCRIPTION
Hi, it's a strict standard warning when you pass non-variable to end function. I was getting that error so I fix that and sending PR... 
