### PR TITLE
Fix the way field classes are loaded so that it is compatible with HHVM

### DIFF
--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -990,36 +990,23 @@ if ( ! class_exists( 'Attachments' ) ) :
          **/
         function get_field_types() {
             $field_types = array(
-                'text'      => ATTACHMENTS_DIR . 'classes/fields/class.field.text.php',
-                'textarea'  => ATTACHMENTS_DIR . 'classes/fields/class.field.textarea.php',
-                'select'    => ATTACHMENTS_DIR . 'classes/fields/class.field.select.php',
-                'wysiwyg'   => ATTACHMENTS_DIR . 'classes/fields/class.field.wysiwyg.php',
+                'text'      => 'Attachments_Field_Text',
+                'textarea'  => 'Attachments_Field_Textarea',
+                'select'    => 'Attachments_Field_Select',
+                'wysiwyg'   => 'Attachments_Field_WYSIWYG',
             );
 
-            // support custom field types
-            // $field_types = apply_filters( 'attachments_fields', $field_types );
-
-            $field_index = 0;
-            foreach ( $field_types as $type => $path ) {
+            foreach ( $field_types as $type => $name ) {
                 // proceed with inclusion
+                $path = ATTACHMENTS_DIR . "classes/fields/class.field.{$type}.php"
                 if ( file_exists( $path ) ) {
-                    // Store a list of all declared classes before we include the file
-                    $existing_classes = get_declared_classes();
-                    
                     // include the file
                     include_once( $path );
-
-                    // Get the new list of classes and find which ones are new
-                    $new_classes = array_diff( get_declared_classes(), $existing_classes );
-
-                    // Add the first class to $field_types
-                    if ( ! empty( $new_classes ) ) {                    
-                        $field_types[ $type ] = $new_classes[0];
-                    }
+                } else {
+                    unset( $field_types[$type] );
                 }
             }
-
-            // send it back
+            
             return $field_types;
         }
 

--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -983,7 +983,7 @@ if ( ! class_exists( 'Attachments' ) ) :
 
         /**
          * Include the basic attachment fields for Text, Textarea, Select, and WYSIWYG
-         * 
+         *
          * @since 3.0
          **/
         function get_field_types() {
@@ -996,7 +996,7 @@ if ( ! class_exists( 'Attachments' ) ) :
             );
 
             foreach ( $field_types as $type => $name ) {
-                $path = ATTACHMENTS_DIR . "classes/fields/class.field.{$type}.php"
+                $path = ATTACHMENTS_DIR . "classes/fields/class.field.{$type}.php";
 
                 if ( file_exists( $path ) ) {
                     // include the file

--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -982,10 +982,8 @@ if ( ! class_exists( 'Attachments' ) ) :
 
 
         /**
-         * Support the inclusion of custom, user-defined field types
-         * Borrowed implementation from Custom Field Suite by Matt Gibbs
-         *      https://uproot.us/docs/creating-custom-field-types/
-         *
+         * Include the basic attachment fields for Text, Textarea, Select, and WYSIWYG
+         * 
          * @since 3.0
          **/
         function get_field_types() {

--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -987,6 +987,7 @@ if ( ! class_exists( 'Attachments' ) ) :
          * @since 3.0
          **/
         function get_field_types() {
+
             $field_types = array(
                 'text'      => 'Attachments_Field_Text',
                 'textarea'  => 'Attachments_Field_Textarea',
@@ -995,8 +996,8 @@ if ( ! class_exists( 'Attachments' ) ) :
             );
 
             foreach ( $field_types as $type => $name ) {
-                // proceed with inclusion
                 $path = ATTACHMENTS_DIR . "classes/fields/class.field.{$type}.php"
+
                 if ( file_exists( $path ) ) {
                     // include the file
                     include_once( $path );
@@ -1004,7 +1005,7 @@ if ( ! class_exists( 'Attachments' ) ) :
                     unset( $field_types[$type] );
                 }
             }
-            
+
             return $field_types;
         }
 

--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -1003,27 +1003,19 @@ if ( ! class_exists( 'Attachments' ) ) :
             foreach ( $field_types as $type => $path ) {
                 // proceed with inclusion
                 if ( file_exists( $path ) ) {
+                    // Store a list of all declared classes before we include the file
+                    $existing_classes = get_declared_classes();
+                    
                     // include the file
                     include_once( $path );
 
-                    // store the registered classes so we can single out what gets added
-                    $existing_classes = get_declared_classes();
+                    // Get the new list of classes and find which ones are new
+                    $new_classes = array_diff( get_declared_classes(), $existing_classes );
 
-                    // we're going to use our Attachments class as a reference because
-                    // during subsequent instantiations of Attachments (e.g. within template files)
-                    // these field classes WILL NOT be added to the array again because
-                    // we're using include_once() so that strategy is no longer useful
-
-                    // determine it's class
-                    $flag = array_search( 'Attachments_Field', $existing_classes );
-
-                    // the field's class is next
-                    $field_class = $existing_classes[$flag + $field_index + 1];
-
-                    // create our link using our new field class
-                    $field_types[ $type ] = $field_class;
-
-                    $field_index++;
+                    // Add the first class to $field_types
+                    if ( ! empty( $new_classes ) ) {                    
+                        $field_types[ $type ] = $new_classes[0];
+                    }
                 }
             }
 


### PR DESCRIPTION
See #146 

Basically it boils down to the fact that we shouldn't rely on `get_declared_classes` to actually be ordered chronologically by inclusion time.  It is kinda fragile and unfortunately it is not how HHVM has implemented `get_declared_classes`.

Instead, I have simply stored the list of classes pre-inclusion then diffed it with the list of classes after inclusion to see what is new. [`array_diff`](http://php.net/manual/en/function.array-diff.php)

Because `$field_types[ $type ]` can only contain 1 class I have discarded any other classes that might have been added and opted to just use the first one in the list `$new_classes[0]`. There should not be a case where a file declared multiple classes AFAIK

Would be great to get this in for the next release so that I don't have to keep applying this patch every time I update the plugin
