### PR TITLE
Updated how to disable Settings screen in docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ Attachments is based on *instances* which correlate directly with the meta boxes
 Attachments ships with a `Settings` screen (found under the `Settings` menu in the main WordPress admin navigation) that facilitates data migration from version 1.x and also offers some code snippets. If you would like to *disable the Settings screen* add the following to your `wp-config.php` *before* `require_once(ABSPATH . 'wp-settings.php');`
 
 ```php
-add_filter( 'attachments_settings_screen', '__return_false' ); // disable the Settings screen
+define( 'ATTACHMENTS_SETTINGS_SCREEN', false ); // disable the Settings screen
 ```
 
 ### Setting Up Instances


### PR DESCRIPTION
The documentation in `docs/usage.md` incorrectly instructs developers to add a method calling the `add_filter` method inside the `wp-config.php` file before:

    require_once(ABSPATH . 'wp-settings.php');

This results in a fatal error, per my comments in #162. I have edited the line in the documentation to instead define a constant as expected at https://github.com/jchristopher/attachments/blob/master/classes/class.attachments.php#L1826.