### PR TITLE
Fixes PHP 7.1.1 illegal offset error

### DIFF
--- a/classes/class.attachments.php
+++ b/classes/class.attachments.php
@@ -1322,7 +1322,7 @@ if ( ! class_exists( 'Attachments' ) ) :
                         // since attributes can change over time (image gets replaced, cropped, etc.) we'll pull that info
                         if ( isset( $attachment->id ) ) {
                             // we'll just use the full size since that's what Media in 3.5 uses
-                            $attachment_meta        = wp_get_attachment_metadata( $attachment->id );
+                            $attachment_meta        = (array)wp_get_attachment_metadata( $attachment->id );
 
                             // only images return the 'file' key
                             if ( ! isset( $attachment_meta['file'] ) ) {


### PR DESCRIPTION
The `wp_get_attachment_metadata( $attachment->id )` returns an empty string (`''`) when there is no attachment_metadata. On PHP 7.1.1, empty strings are not implicitly converted to arrays when one attempts to assign a value to a string key on that variable, and instead return a warning.

This fix does explicit conversion of `wp_get_attachment_metadata( $attachment->id )` to an array to avoid the `illegal offset 'file'` when running on PHP 7.1.1.

fixes #173 