### PR TITLE
Fix documentation links on WordPress plugins page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -89,7 +89,7 @@ Please see [Issues on GitHub](https://github.com/jchristopher/attachments/issues
 
 == Changelog ==
 
-Please see [Attachments' changelog on GitHub](https://github.com/jchristopher/attachments/docs/changelog.md)
+Please see [Attachments' changelog on GitHub](https://github.com/jchristopher/attachments/blob/master/docs/changelog.md)
 
 = 3.5.9 =
 * Added link to collapse Attachments to make sorting easier
@@ -282,8 +282,8 @@ Now piggybacking the awesome Media workflow introduced in WordPress 3.5
 
 == Roadmap ==
 
-Please see [Attachments on GitHub](https://github.com/jchristopher/attachments/docs/roadmap.md)
+Please see [Attachments on GitHub](https://github.com/jchristopher/attachments/blob/master/docs/roadmap.md)
 
 == Usage ==
 
-**Extensive** usage instructions are [available on GitHub](https://github.com/jchristopher/docs/usage.md)
+**Extensive** usage instructions are [available on GitHub](https://github.com/jchristopher/attachments/blob/master/docs/usage.md)


### PR DESCRIPTION
The links to individual files within Github on the WordPress plugins repository do not work. Updated these to include the brand (master)

For example, check the "Extensive usage instructions" here:
 - https://en-gb.wordpress.org/plugins/attachments/