### PR TITLE
Fixed bug in generated code for migration from Attachments Pro

### DIFF
--- a/classes/class.attachments.migrate.php
+++ b/classes/class.attachments.migrate.php
@@ -645,8 +645,12 @@ if( !function_exists( 'attachments_magic_tags_processor' ) )
                 // we are dealing with a field
                 $field = explode( '_', $name );
 
-                if( isset( $field[1] ) )
-                    $value = $attachments_auto_append_ref->field( $field[1] );
+                $single_attachment = $attachments_auto_append_ref->get_single( $attachments_magic_tag_index - 1 );
+                $field_names = array_keys( get_object_vars ( $single_attachment->fields ) );
+                $field_index = $field[1] - 1;
+
+                if( isset( $field_names[ $field_index ] ) )
+                    $value = $attachments_auto_append_ref->field( $field_names[ $field_index ] );
             }
         }
 


### PR DESCRIPTION
The original implementation was not correct because it was passing an unexpected value to the method "field" (it expects the field name).
The proposed implementation is a bit tricky because at the moment there's not an easy way to get the field names from the Attachments class.