### PR TITLE
Fix deleting media error

### DIFF
--- a/classes/class.attachments.search.php
+++ b/classes/class.attachments.search.php
@@ -61,8 +61,10 @@ class AttachmentsSearch extends Attachments {
         }
 
         // since we have an array for our fields, we need to loop through and sanitize
-        for ( $i = 0; $i < count( $params['fields'] ); $i++ ) {
-            $params['fields'][ $i ] = sanitize_text_field( $params['fields'][ $i ] );
+        if( $params['fields'] !== null ) {
+            for ( $i = 0; $i < count( $params['fields'] ); $i++ ) {
+                $params['fields'][ $i ] = sanitize_text_field( $params['fields'][ $i ] );
+            }
         }
 
         // prepare our search args


### PR DESCRIPTION
While deleting a media, you might get an error about classes/class.attachments.search.php:64 count() expecting an array and getting a null value.
The $params['fields'] var might be an array or a null value (by default). If null, the count() function in the for loop (line 65) returns an error. Adding the if statement (line 64) resolves the problem.